### PR TITLE
Fix incorrect live matches endpoint

### DIFF
--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -7,7 +7,8 @@ export const API_CONFIG = {
       SEASONS: '/competitions/{competition_id}/seasons',
       STANDINGS: '/seasons/{season_id}/standings',
       MATCHES: '/seasons/{season_id}/schedules',
-      LIVE_MATCHES: '/seasons/{season_id}/live_standings',
+      // Endpoint for currently live matches
+      LIVE_MATCHES: '/seasons/{season_id}/schedules/live',
       MATCH_SUMMARY: '/matches/{match_id}/summary',
       PLAYER_STATS: '/seasons/{season_id}/players',
       TEAM_STATS: '/seasons/{season_id}/teams'


### PR DESCRIPTION
## Summary
- correct SportRadar live matches API endpoint

## Testing
- `npm run build` *(fails: ESLint or TS config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68438e0eaac0832eb77216c73ce47709