### PR TITLE
Use useRef in useApiData

### DIFF
--- a/src/components/LiveMatches.tsx
+++ b/src/components/LiveMatches.tsx
@@ -15,7 +15,7 @@ const LiveMatches: React.FC = () => {
     error: matchesError,
     lastUpdated: matchesLastUpdated,
     refresh: refreshMatches
-  } = useApiData(() => sportRadarService.getMatches(), {
+  } = useApiData(sportRadarService.getMatches, {
     refreshInterval: 60000 // Refresh every minute for general matches
   });
 
@@ -26,7 +26,7 @@ const LiveMatches: React.FC = () => {
     error: liveError,
     lastUpdated: liveLastUpdated,
     refresh: refreshLive
-  } = useApiData(() => sportRadarService.getLiveMatches(), {
+  } = useApiData(sportRadarService.getLiveMatches, {
     refreshInterval: 30000 // Refresh every 30 seconds for live matches
   });
 

--- a/src/components/PlayerStats.tsx
+++ b/src/components/PlayerStats.tsx
@@ -13,7 +13,7 @@ const PlayerStats: React.FC = () => {
     error,
     lastUpdated,
     refresh
-  } = useApiData(() => sportRadarService.getPlayerStats(), {
+  } = useApiData(sportRadarService.getPlayerStats, {
     refreshInterval: 300000 // Refresh every 5 minutes for player stats
   });
 

--- a/src/components/Standings.tsx
+++ b/src/components/Standings.tsx
@@ -11,7 +11,7 @@ const Standings: React.FC = () => {
     error,
     lastUpdated,
     refresh
-  } = useApiData(() => sportRadarService.getStandings(), {
+  } = useApiData(sportRadarService.getStandings, {
     refreshInterval: 300000 // Refresh every 5 minutes for standings
   });
 

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { API_CONFIG } from '../config/api';
 
 interface UseApiDataOptions {
@@ -14,18 +14,23 @@ export function useApiData<T>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const fetchFunctionRef = useRef(fetchFunction);
 
   const {
     refreshInterval = API_CONFIG.LIVE_UPDATE_INTERVAL,
     enabled = true
   } = options;
 
+  useEffect(() => {
+    fetchFunctionRef.current = fetchFunction;
+  }, [fetchFunction]);
+
   const fetchData = useCallback(async () => {
     if (!enabled) return;
 
     try {
       setError(null);
-      const result = await fetchFunction();
+      const result = await fetchFunctionRef.current();
       setData(result);
       setLastUpdated(new Date());
     } catch (err) {
@@ -34,7 +39,7 @@ export function useApiData<T>(
     } finally {
       setLoading(false);
     }
-  }, [fetchFunction, enabled]);
+  }, [enabled]);
 
   const refresh = useCallback(() => {
     setLoading(true);

--- a/src/services/sportRadarService.ts
+++ b/src/services/sportRadarService.ts
@@ -134,7 +134,7 @@ class SportRadarService {
     return 'TBD';
   }
 
-  async getMatches(): Promise<Match[]> {
+  getMatches = async (): Promise<Match[]> => {
     try {
       const url = API_CONFIG.SPORTRADAR.ENDPOINTS.MATCHES
         .replace('{season_id}', CURRENT_SEASON_ID);
@@ -166,7 +166,7 @@ class SportRadarService {
     }
   }
 
-  async getLiveMatches(): Promise<Match[]> {
+  getLiveMatches = async (): Promise<Match[]> => {
     try {
       const url = API_CONFIG.SPORTRADAR.ENDPOINTS.LIVE_MATCHES
         .replace('{season_id}', CURRENT_SEASON_ID);
@@ -197,7 +197,7 @@ class SportRadarService {
     }
   }
 
-  async getStandings(): Promise<StandingsTeam[]> {
+  getStandings = async (): Promise<StandingsTeam[]> => {
     try {
       const url = API_CONFIG.SPORTRADAR.ENDPOINTS.STANDINGS
         .replace('{season_id}', CURRENT_SEASON_ID);
@@ -224,7 +224,7 @@ class SportRadarService {
     }
   }
 
-  async getPlayerStats(): Promise<Player[]> {
+  getPlayerStats = async (): Promise<Player[]> => {
     try {
       const url = API_CONFIG.SPORTRADAR.ENDPOINTS.PLAYER_STATS
         .replace('{season_id}', CURRENT_SEASON_ID);


### PR DESCRIPTION
## Summary
- store provided fetch function in a ref and call via reference
- convert SportRadarService methods to arrow functions
- update component hooks to pass service methods directly

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68438f57c804832ea9909b23d1684a61