### PR TITLE
Switch to Zyla API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for NRL Stats app using Zyla API
+VITE_ZYLA_API_KEY=your_zyla_api_key_here
+VITE_ZYLA_BASE_URL=https://api.zyla.com/nrl/v1
+VITE_API_CACHE_DURATION=300000
+VITE_LIVE_UPDATE_INTERVAL=30000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NRL Live Stats
 
-A modern, real-time NRL (National Rugby League) statistics application built with React, TypeScript, and Tailwind CSS. Features live match scores, player statistics, and team standings with SportRadar API integration.
+A modern, real-time NRL (National Rugby League) statistics application built with React, TypeScript, and Tailwind CSS. Features live match scores, player statistics, and team standings with Zyla API integration.
 
 ## Features
 
@@ -17,7 +17,7 @@ A modern, real-time NRL (National Rugby League) statistics application built wit
 - **Frontend**: React 18, TypeScript, Tailwind CSS
 - **Build Tool**: Vite
 - **HTTP Client**: Axios
-- **API**: SportRadar Rugby League API
+- **API**: Zyla Rugby League API
 - **Icons**: Lucide React
 
 ## Getting Started
@@ -25,7 +25,7 @@ A modern, real-time NRL (National Rugby League) statistics application built wit
 ### Prerequisites
 
 - Node.js 16+ and npm
-- SportRadar API key (sign up at [SportRadar](https://developer.sportradar.com/))
+- Zyla API key (sign up at [Zyla](https://zylalabs.com))
 
 ### Installation
 
@@ -47,8 +47,8 @@ cp .env.example .env
 
 4. Configure your environment variables in `.env`:
 ```env
-VITE_SPORTRADAR_API_KEY=your_sportradar_api_key_here
-VITE_SPORTRADAR_BASE_URL=https://api.sportradar.us/rugby-league/trial/v2/en
+VITE_ZYLA_API_KEY=your_zyla_api_key_here
+VITE_ZYLA_BASE_URL=https://api.zyla.com/nrl/v1
 VITE_API_CACHE_DURATION=300000
 VITE_LIVE_UPDATE_INTERVAL=30000
 ```
@@ -60,10 +60,10 @@ npm run dev
 
 ## API Configuration
 
-### SportRadar Setup
+### Zyla Setup
 
-1. Sign up for a SportRadar developer account
-2. Subscribe to the Rugby League API
+1. Sign up for a Zyla developer account
+2. Subscribe to the NRL Rugby League API
 3. Get your API key from the dashboard
 4. Update the `.env` file with your credentials
 
@@ -124,21 +124,21 @@ src/
 ### API Service Architecture
 
 - `apiClient`: HTTP client with caching and retry logic
-- `sportRadarService`: SportRadar API integration
+- `zylaService`: Zyla API integration
 - `useApiData`: React hook for data fetching and state management
 
 ## Configuration Options
 
 ### Environment Variables
 
-- `VITE_SPORTRADAR_API_KEY`: Your SportRadar API key
-- `VITE_SPORTRADAR_BASE_URL`: SportRadar API base URL
+- `VITE_ZYLA_API_KEY`: Your Zyla API key
+- `VITE_ZYLA_BASE_URL`: Zyla API base URL
 - `VITE_API_CACHE_DURATION`: Cache duration in milliseconds (default: 5 minutes)
 - `VITE_LIVE_UPDATE_INTERVAL`: Live data refresh interval (default: 30 seconds)
 
 ### Customization
 
-- Update team logos in `sportRadarService.ts`
+- Update team logos in `zylaService.ts`
 - Modify refresh intervals in component configurations
 - Adjust caching strategies in `apiClient.ts`
 
@@ -173,7 +173,7 @@ This project is licensed under the MIT License.
 ## Support
 
 For issues and questions:
-- Check the SportRadar API documentation
+- Check the Zyla API documentation
 - Review the error handling in browser console
 - Ensure your API key has proper permissions
 - Verify network connectivity for live features

--- a/src/components/LiveMatches.tsx
+++ b/src/components/LiveMatches.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Clock, MapPin, Users, RefreshCw, Wifi, WifiOff } from 'lucide-react';
 import MatchCard from './MatchCard';
 import { Match } from '../types/Match';
-import { sportRadarService } from '../services/sportRadarService';
+import { zylaService } from '../services/zylaService';
 import { useApiData } from '../hooks/useApiData';
 
 const LiveMatches: React.FC = () => {
@@ -15,7 +15,7 @@ const LiveMatches: React.FC = () => {
     error: matchesError,
     lastUpdated: matchesLastUpdated,
     refresh: refreshMatches
-  } = useApiData(sportRadarService.getMatches, {
+  } = useApiData(zylaService.getMatches, {
     refreshInterval: 60000 // Refresh every minute for general matches
   });
 
@@ -26,7 +26,7 @@ const LiveMatches: React.FC = () => {
     error: liveError,
     lastUpdated: liveLastUpdated,
     refresh: refreshLive
-  } = useApiData(sportRadarService.getLiveMatches, {
+  } = useApiData(zylaService.getLiveMatches, {
     refreshInterval: 30000 // Refresh every 30 seconds for live matches
   });
 

--- a/src/components/PlayerStats.tsx
+++ b/src/components/PlayerStats.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Award, Target, Zap, Shield, RefreshCw, AlertCircle } from 'lucide-react';
 import { Player } from '../types/Player';
-import { sportRadarService } from '../services/sportRadarService';
+import { zylaService } from '../services/zylaService';
 import { useApiData } from '../hooks/useApiData';
 
 const PlayerStats: React.FC = () => {
@@ -13,7 +13,7 @@ const PlayerStats: React.FC = () => {
     error,
     lastUpdated,
     refresh
-  } = useApiData(sportRadarService.getPlayerStats, {
+  } = useApiData(zylaService.getPlayerStats, {
     refreshInterval: 300000 // Refresh every 5 minutes for player stats
   });
 

--- a/src/components/Standings.tsx
+++ b/src/components/Standings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { TrendingUp, TrendingDown, Minus, RefreshCw, AlertCircle } from 'lucide-react';
 import { Team } from '../types/Standings';
-import { sportRadarService } from '../services/sportRadarService';
+import { zylaService } from '../services/zylaService';
 import { useApiData } from '../hooks/useApiData';
 
 const Standings: React.FC = () => {
@@ -11,7 +11,7 @@ const Standings: React.FC = () => {
     error,
     lastUpdated,
     refresh
-  } = useApiData(sportRadarService.getStandings, {
+  } = useApiData(zylaService.getStandings, {
     refreshInterval: 300000 // Refresh every 5 minutes for standings
   });
 

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,14 +1,14 @@
 export const API_CONFIG = {
-  SPORTRADAR: {
-    BASE_URL: import.meta.env.VITE_SPORTRADAR_BASE_URL || 'https://api.sportradar.us/rugby-league/trial/v2/en',
-    API_KEY: import.meta.env.VITE_SPORTRADAR_API_KEY || '',
+  ZYLA: {
+    BASE_URL: import.meta.env.VITE_ZYLA_BASE_URL || 'https://api.zyla.com/nrl/v1',
+    API_KEY: import.meta.env.VITE_ZYLA_API_KEY || '',
     ENDPOINTS: {
       COMPETITIONS: '/competitions',
       SEASONS: '/competitions/{competition_id}/seasons',
       STANDINGS: '/seasons/{season_id}/standings',
-      MATCHES: '/seasons/{season_id}/schedules',
+      MATCHES: '/seasons/{season_id}/matches',
       // Endpoint for currently live matches
-      LIVE_MATCHES: '/seasons/{season_id}/schedules/live',
+      LIVE_MATCHES: '/seasons/{season_id}/matches/live',
       MATCH_SUMMARY: '/matches/{match_id}/summary',
       PLAYER_STATS: '/seasons/{season_id}/players',
       TEAM_STATS: '/seasons/{season_id}/teams'
@@ -20,6 +20,6 @@ export const API_CONFIG = {
   MAX_RETRIES: 3
 };
 
-// NRL Competition ID (this would be obtained from SportRadar)
-export const NRL_COMPETITION_ID = 'sr:competition:1234'; // Replace with actual NRL competition ID
-export const CURRENT_SEASON_ID = 'sr:season:5678'; // Replace with current season ID
+// NRL Competition ID (obtain from your Zyla dashboard)
+export const NRL_COMPETITION_ID = 'zyla:competition:1234'; // Replace with actual NRL competition ID
+export const CURRENT_SEASON_ID = 'zyla:season:5678'; // Replace with current season ID

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -6,13 +6,13 @@ class ApiClient {
   private cache: Map<string, { data: any; timestamp: number }> = new Map();
 
   constructor() {
-    this.client = axios.create({
-      baseURL: API_CONFIG.SPORTRADAR.BASE_URL,
-      timeout: API_CONFIG.REQUEST_TIMEOUT,
-      params: {
-        api_key: API_CONFIG.SPORTRADAR.API_KEY
-      }
-    });
+      this.client = axios.create({
+        baseURL: API_CONFIG.ZYLA.BASE_URL,
+        timeout: API_CONFIG.REQUEST_TIMEOUT,
+        params: {
+          apikey: API_CONFIG.ZYLA.API_KEY
+        }
+      });
 
     // Request interceptor for logging
     this.client.interceptors.request.use(

--- a/src/services/zylaService.ts
+++ b/src/services/zylaService.ts
@@ -4,7 +4,7 @@ import { Match } from '../types/Match';
 import { Team as StandingsTeam } from '../types/Standings';
 import { Player } from '../types/Player';
 
-export interface SportRadarMatch {
+export interface ZylaMatch {
   id: string;
   scheduled: string;
   status: string;
@@ -32,7 +32,7 @@ export interface SportRadarMatch {
   clock?: string;
 }
 
-export interface SportRadarStandings {
+export interface ZylaStandings {
   standings: Array<{
     team: {
       id: string;
@@ -51,7 +51,7 @@ export interface SportRadarStandings {
   }>;
 }
 
-export interface SportRadarPlayerStats {
+export interface ZylaPlayerStats {
   players: Array<{
     id: string;
     name: string;
@@ -72,7 +72,7 @@ export interface SportRadarPlayerStats {
   }>;
 }
 
-class SportRadarService {
+class ZylaService {
   private teamLogos: { [key: string]: string } = {
     'penrith': '🐆',
     'melbourne': '⚡',
@@ -118,7 +118,7 @@ class SportRadarService {
     }
   }
 
-  private formatMatchTime(match: SportRadarMatch): string {
+  private formatMatchTime(match: ZylaMatch): string {
     if (match.status === 'inprogress' && match.clock) {
       return match.clock;
     }
@@ -136,10 +136,10 @@ class SportRadarService {
 
   getMatches = async (): Promise<Match[]> => {
     try {
-      const url = API_CONFIG.SPORTRADAR.ENDPOINTS.MATCHES
+        const url = API_CONFIG.ZYLA.ENDPOINTS.MATCHES
         .replace('{season_id}', CURRENT_SEASON_ID);
       
-      const response = await apiClient.get<{ schedules: SportRadarMatch[] }>(url);
+        const response = await apiClient.get<{ schedules: ZylaMatch[] }>(url);
       
       return response.schedules.map((match): Match => ({
         id: match.id,
@@ -168,10 +168,10 @@ class SportRadarService {
 
   getLiveMatches = async (): Promise<Match[]> => {
     try {
-      const url = API_CONFIG.SPORTRADAR.ENDPOINTS.LIVE_MATCHES
+        const url = API_CONFIG.ZYLA.ENDPOINTS.LIVE_MATCHES
         .replace('{season_id}', CURRENT_SEASON_ID);
       
-      const response = await apiClient.get<{ matches: SportRadarMatch[] }>(url, {}, false); // Don't cache live data
+        const response = await apiClient.get<{ matches: ZylaMatch[] }>(url, {}, false); // Don't cache live data
       
       return response.matches.map((match): Match => ({
         id: match.id,
@@ -199,10 +199,10 @@ class SportRadarService {
 
   getStandings = async (): Promise<StandingsTeam[]> => {
     try {
-      const url = API_CONFIG.SPORTRADAR.ENDPOINTS.STANDINGS
+        const url = API_CONFIG.ZYLA.ENDPOINTS.STANDINGS
         .replace('{season_id}', CURRENT_SEASON_ID);
       
-      const response = await apiClient.get<SportRadarStandings>(url);
+        const response = await apiClient.get<ZylaStandings>(url);
       
       return response.standings.map((standing): StandingsTeam => ({
         position: standing.rank,
@@ -226,10 +226,10 @@ class SportRadarService {
 
   getPlayerStats = async (): Promise<Player[]> => {
     try {
-      const url = API_CONFIG.SPORTRADAR.ENDPOINTS.PLAYER_STATS
+        const url = API_CONFIG.ZYLA.ENDPOINTS.PLAYER_STATS
         .replace('{season_id}', CURRENT_SEASON_ID);
       
-      const response = await apiClient.get<SportRadarPlayerStats>(url);
+        const response = await apiClient.get<ZylaPlayerStats>(url);
       
       return response.players.map((player): Player => ({
         name: player.name,
@@ -309,4 +309,4 @@ class SportRadarService {
   }
 }
 
-export const sportRadarService = new SportRadarService();
+export const zylaService = new ZylaService();


### PR DESCRIPTION
## Summary
- migrate API integration from SportRadar to Zyla
- rename service and update components
- document new env vars and provide `.env.example`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439a1a6d2c832e9f6383fa81872764